### PR TITLE
Prevent sensors from disappearing overnight

### DIFF
--- a/solarhtml2json.py
+++ b/solarhtml2json.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 
 def get_power_data():
-    url = 'http://192.168.86.69/cgi-bin/parameters'
+    url = 'http://IP-OF-ECU-3/cgi-bin/parameters'
     r = requests.get(url)
     
     if r.status_code != 200:

--- a/solarhtml2json.py
+++ b/solarhtml2json.py
@@ -49,7 +49,7 @@ def get_power_data():
     # For missing panels (offline over night etc) fill in the latest timestamp
     # found. If all are offline, fill in the current time.
     if latest_time == '0':
-        latest_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        latest_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     for pannel in power_data:
         if power_data[pannel][4] == '0':
             power_data[pannel][4] = latest_time

--- a/solarhtml2json.py
+++ b/solarhtml2json.py
@@ -1,9 +1,10 @@
 import requests
 from bs4 import BeautifulSoup
+from datetime import datetime
 import json
 
 def get_power_data():
-    url = 'http://IP-OF-ECU-3/cgi-bin/parameters'
+    url = 'http://192.168.86.69/cgi-bin/parameters'
     r = requests.get(url)
     
     if r.status_code != 200:
@@ -28,12 +29,30 @@ def get_power_data():
         else :
             print('Not a power data row')
 
-    # Remove units from the data
-    for key in power_data:
-        power_data[key][0] = power_data[key][0].replace(' W', '')
-        power_data[key][1] = power_data[key][1].replace(' Hz', '')
-        power_data[key][2] = power_data[key][2].replace(' V', '')
-        power_data[key][3] = power_data[key][3].replace(' oC', '')
+    # Clean the data
+    latest_time = '0'
+    for pannel in power_data:
+        if pannel != 'Inverter ID':  # skip the row of headers
+            # Remove units from the data
+            power_data[pannel][0] = power_data[pannel][0].replace(' W', '')
+            power_data[pannel][1] = power_data[pannel][1].replace(' Hz', '')
+            power_data[pannel][2] = power_data[pannel][2].replace(' V', '')
+            power_data[pannel][3] = power_data[pannel][3].replace(' oC', '')
+
+            # Panels go offline at night and return empty values. Mark these as 0
+            # instead to prevent the HA sensor from disappearing.
+            power_data[pannel] = [d.strip() or '0' for d in power_data[pannel]]
+            
+            # Note the latest timestamp found so we can fill it in for missing
+            # panels.
+            latest_time = max(latest_time, power_data[pannel][4])
+    # For missing panels (offline over night etc) fill in the latest timestamp
+    # found. If all are offline, fill in the current time.
+    if latest_time == '0':
+        latest_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    for pannel in power_data:
+        if power_data[pannel][4] == '0':
+            power_data[pannel][4] = latest_time
         
     with open('www/power_data.json', 'w') as outfile:
         json.dump(power_data, outfile)


### PR DESCRIPTION
As the sun goes down, my solar ECU-3 returns empty values for watts etc for each panel as it goes offline. This PR replaces the empty values with "0" (for numeric fields) and a reasonable substitute timestamp. This allows the sensor to stay visible in Home Assistant overnight.

I.E.
`"403000056327-B": ["", "", "", "", ""]`
becomes
`"403000056327-B": ["0", "0", "0", "0", "2023-10-05 18:34:33"]`